### PR TITLE
:bug: MC_X fails if device does not exist

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -24,7 +24,7 @@ required_conan_version = ">=2.0.6"
 
 class libhal_rmd_conan(ConanFile):
     name = "libhal-rmd"
-    version = "3.2.0"
+    version = "3.2.1"
     license = "Apache-2.0"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-rmd"

--- a/src/mc_x.cpp
+++ b/src/mc_x.cpp
@@ -133,6 +133,11 @@ result<mc_x> mc_x::create(hal::can_router& p_router,
 {
   mc_x mc_x_driver(
     p_router, p_clock, p_gear_ratio, device_id, p_max_response_time);
+
+  // This is used to detect if the device is present, will throw a timeout if
+  // the device is not present.
+  HAL_CHECK(mc_x_driver.feedback_request(read::multi_turns_angle));
+
   return mc_x_driver;
 }
 


### PR DESCRIPTION
Constructors and create functions should put the device in a working state and succeed only if they are usable. Failure to do so confuses the user. This fixes that for this driver.